### PR TITLE
Adding a configurable UID:GID for the tika process to run as so it do…

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,9 @@
 # limitations under the License.
 
 TAG=1.28.1
+# For 2.x series
+#TIKA_JAR=tika-server-standard
+#TIKA_SERVER_CLASS=org.apache.tika.server.core.TikaServerCli
+# For 1.x series
+TIKA_JAR=tika-server
+TIKA_SERVER_CLASS=org.apache.tika.server.TikaServerCli

--- a/.env
+++ b/.env
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=1.28
+TAG=1.28.1

--- a/.env
+++ b/.env
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=1.27
+TAG=1.28

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: bash
 services: docker
 env:
   matrix:
-    - VERSION=2.1.0 TIKA_JAR=tika-server-standard
-    - VERSION=2.0.0 TIKA_JAR=tika-server-standard
-    - VERSION=1.27 TIKA_JAR=tika-server
-    - VERSION=1.26 TIKA_JAR=tika-server
+    - VERSION=2.2.1 TIKA_JAR=tika-server-standard
+    - VERSION=1.28 TIKA_JAR=tika-server
 
 script:
   - ./docker-tool.sh build $VERSION $TIKA_JAR

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: bash
 services: docker
 env:
   matrix:
-    - VERSION=2.2.1 TIKA_JAR=tika-server-standard
+    - VERSION=2.3.0 TIKA_JAR=tika-server-standard
     - VERSION=1.28 TIKA_JAR=tika-server
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 env:
   matrix:
     - VERSION=2.3.0 TIKA_JAR=tika-server-standard
-    - VERSION=1.28 TIKA_JAR=tika-server
+    - VERSION=1.28.1 TIKA_JAR=tika-server
 
 script:
   - ./docker-tool.sh build $VERSION $TIKA_JAR

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Below are the most recent 2.x series tags:
 
 Below are the most recent 1.x series tags:
 
+- `1.28.1`: Apache Tika Server 1.28.1 (Minimal)
+- `1.28.1-full`: Apache Tika Server 1.28.1 (Full)
 - `1.28`: Apache Tika Server 1.28 (Minimal)
 - `1.28-full`: Apache Tika Server 1.28 (Full)
 - `1.27`: Apache Tika Server 1.27 (Minimal)
 - `1.27-full`: Apache Tika Server 1.27 (Full)
 - `1.26`: Apache Tika Server 1.26 (Minimal)
 - `1.26-full`: Apache Tika Server 1.26 (Full)
-- `1.25`: Apache Tika Server 1.25 (Minimal)
-- `1.25-full`: Apache Tika Server 1.25 (Full)
 
 You can see a full set of tags for historical versions [here](https://hub.docker.com/r/apache/tika/tags?page=1&ordering=last_updated).
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Below are the most recent 1.x series tags:
 
 Below are the most recent 2.x series tags:
 
-- `2.2.1`: Apache Tika Server 2.2.0 (Minimal)
+- `2.2.1`: Apache Tika Server 2.2.1 (Minimal)
 - `2.2.1-full`: Apache Tika Server 2.2.1 (Full)
 - `2.2.0`: Apache Tika Server 2.2.0 (Minimal)
 - `2.2.0-full`: Apache Tika Server 2.2.0 (Full)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Below are the most recent 1.x series tags:
 
 Below are the most recent 2.x series tags:
 
+- `2.2.0`: Apache Tika Server 2.2.0 (Minimal)
+- `2.2.0-full`: Apache Tika Server 2.2.0 (Full)
 - `2.1.0`: Apache Tika Server 2.1.0 (Minimal)
 - `2.1.0-full`: Apache Tika Server 2.1.0 (Full)
 - `2.0.0`: Apache Tika Server 2.0.0 (Minimal)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is used to create convenience Docker images for Apache Tika Server published as [apache/tika](https://hub.docker.com/r/apache/tika) on DockerHub by the [Apache Tika](http://tika.apache.org) Dev team
 
-The images create a functional Apache Tika Server instance that contains the latest Ubuntu running the appropriate version's server on Port 9998 using Java 8 (until version 1.20), Java 11 (1.21 and 1.24.1), Java 14 (until 1.27/2.0.0), and Java 16 for newer versions.
+The images create a functional Apache Tika Server instance that contains the latest Ubuntu running the appropriate version's server on Port 9998 using Java 8 (until version 1.20), Java 11 (1.21 and 1.24.1), Java 14 (until 1.27/2.0.0), Java 16 (for 2.1.0), and Java 17 LTS for newer versions.
 
 There is a minimal version, which contains only Apache Tika and it's core dependencies, and a full version, which also includes dependencies for the GDAL and Tesseract OCR parsers. To balance showing functionality versus the size of the full image, this file currently installs the language packs for the following languages:
 * English
@@ -107,6 +107,8 @@ You can then use the following command (using the name you allocated in the buil
 For more infomation on Apache Tika Server, go to the [Apache Tika Server documentation](https://cwiki.apache.org/confluence/display/TIKA/TikaServer).
 
 For more information on Apache Tika, go to the official [Apache Tika](http://tika.apache.org) project website.
+
+To meet up with others using Apache Tika, consider coming to one of the [Apache Tika Virtual Meetups](https://www.meetup.com/apache-tika-community/).
 
 For more information on the Apache Software Foundation, go to the [Apache Software Foundation](http://apache.org) website.
 

--- a/README.md
+++ b/README.md
@@ -15,25 +15,27 @@ To install more languages simply update the apt-get command to include the packa
 
 ## Available Tags
 
-Below are the most recent 1.x series tags:
-
-- `latest`, `1.28`: Apache Tika Server 1.28 (Minimal)
-- `latest-full`, `1.28-full`: Apache Tika Server 1.28 (Full)
-- `1.27`: Apache Tika Server 1.27 (Minimal)
-- `1.27-full`: Apache Tika Server 1.27 (Full)
-- `1.26`: Apache Tika Server 1.26 (Minimal)
-- `1.26-full`: Apache Tika Server 1.26 (Full)
-- `1.25`: Apache Tika Server 1.25 (Minimal)
-- `1.25-full`: Apache Tika Server 1.25 (Full)
-
 Below are the most recent 2.x series tags:
 
+- `latest`, `2.3.0`: Apache Tika Server 2.3.0 (Minimal)
+- `latest-full`, `2.3.0-full`: Apache Tika Server 2.3.0 (Full)
 - `2.2.1`: Apache Tika Server 2.2.1 (Minimal)
 - `2.2.1-full`: Apache Tika Server 2.2.1 (Full)
 - `2.2.0`: Apache Tika Server 2.2.0 (Minimal)
 - `2.2.0-full`: Apache Tika Server 2.2.0 (Full)
 - `2.1.0`: Apache Tika Server 2.1.0 (Minimal)
 - `2.1.0-full`: Apache Tika Server 2.1.0 (Full)
+
+Below are the most recent 1.x series tags:
+
+- `1.28`: Apache Tika Server 1.28 (Minimal)
+- `1.28-full`: Apache Tika Server 1.28 (Full)
+- `1.27`: Apache Tika Server 1.27 (Minimal)
+- `1.27-full`: Apache Tika Server 1.27 (Full)
+- `1.26`: Apache Tika Server 1.26 (Minimal)
+- `1.26-full`: Apache Tika Server 1.26 (Full)
+- `1.25`: Apache Tika Server 1.25 (Minimal)
+- `1.25-full`: Apache Tika Server 1.25 (Full)
 
 You can see a full set of tags for historical versions [here](https://hub.docker.com/r/apache/tika/tags?page=1&ordering=last_updated).
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ To install more languages simply update the apt-get command to include the packa
 
 Below are the most recent 1.x series tags:
 
-- `latest`, `1.27`: Apache Tika Server 1.27 (Minimal)
-- `latest-full`, `1.27-full`: Apache Tika Server 1.27 (Full)
+- `latest`, `1.28`: Apache Tika Server 1.28 (Minimal)
+- `latest-full`, `1.28-full`: Apache Tika Server 1.28 (Full)
+- `1.27`: Apache Tika Server 1.27 (Minimal)
+- `1.27-full`: Apache Tika Server 1.27 (Full)
 - `1.26`: Apache Tika Server 1.26 (Minimal)
 - `1.26-full`: Apache Tika Server 1.26 (Full)
 - `1.25`: Apache Tika Server 1.25 (Minimal)
 - `1.25-full`: Apache Tika Server 1.25 (Full)
-- `1.24.1`: Apache Tika Server 1.24.1 (Minimal)
-- `1.24.1-full`: Apache Tika Server 1.24.1 (Full)
 
 Below are the most recent 2.x series tags:
 
+- `2.2.1`: Apache Tika Server 2.2.0 (Minimal)
+- `2.2.1-full`: Apache Tika Server 2.2.1 (Full)
 - `2.2.0`: Apache Tika Server 2.2.0 (Minimal)
 - `2.2.0-full`: Apache Tika Server 2.2.0 (Full)
 - `2.1.0`: Apache Tika Server 2.1.0 (Minimal)
 - `2.1.0-full`: Apache Tika Server 2.1.0 (Full)
-- `2.0.0`: Apache Tika Server 2.0.0 (Minimal)
-- `2.0.0-full`: Apache Tika Server 2.0.0 (Full)
 
 You can see a full set of tags for historical versions [here](https://hub.docker.com/r/apache/tika/tags?page=1&ordering=last_updated).
 

--- a/docker-compose-tika-customocr.yml
+++ b/docker-compose-tika-customocr.yml
@@ -20,7 +20,7 @@ services:
   tika:
     image: apache/tika:${TAG}-full
     # Override default so we can add configuration on classpath
-    entrypoint: [ "/bin/sh", "-c", "exec java -cp /customocr:/tika-server-${TAG}.jar org.apache.tika.server.TikaServerCli -h 0.0.0.0 $$0 $$@"]
+    entrypoint: [ "/bin/sh", "-c", "exec java -cp /customocr:/${TIKA_JAR}-${TAG}.jar org.apache.tika.server.TikaServerCli -h 0.0.0.0 $$0 $$@"]
     # Kept command as example but could be added to entrypoint too
     command: -c /tika-config.xml
     restart: on-failure

--- a/docker-compose-tika-grobid.yml
+++ b/docker-compose-tika-grobid.yml
@@ -20,7 +20,7 @@ services:
   tika:
     image: apache/tika:${TAG}-full
     # Override default so we can add configuration on classpath
-    entrypoint: [ "/bin/sh", "-c", "exec java -cp /grobid:/tika-server-${TAG}.jar org.apache.tika.server.TikaServerCli -h 0.0.0.0 $$0 $$@"]
+    entrypoint: [ "/bin/sh", "-c", "exec java -cp /grobid:/${TIKA_JAR}-${TAG}.jar ${TIKA_SERVER_CLASS} -h 0.0.0.0 $$0 $$@"]
     # Kept command as example but could be added to entrypoint too
     command: -c /grobid/tika-config.xml
     restart: on-failure

--- a/docker-compose-tika-ner.yml
+++ b/docker-compose-tika-ner.yml
@@ -26,5 +26,8 @@ services:
       - "9998:9998"
     volumes:
       -  ./sample-configs/ner/:/ner/
-
+    environment:
+      - TAG
+      - TIKA_JAR
+      - TIKA_SERVER_CLASS
    

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -62,7 +62,7 @@ jar=$1; shift
 
 if [ -z "$jar" ]
 then
-  jar="tika-server"
+  jar="tika-server-standard"
 fi
 
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update
 
 FROM base as dependencies
 ARG JRE='openjdk-14-jre-headless'
+# "random" uid/gid hopefully not used anywhere else
+ARG UID_GID="35002:35002"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr \
         tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
@@ -47,7 +49,7 @@ RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
-
+USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:focal as base
 RUN apt-get update
 
 FROM base as dependencies
-ARG JRE='openjdk-16-jre-headless'
+ARG JRE='openjdk-17-jre-headless'
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr \
         tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
@@ -49,7 +49,6 @@ RUN if [ "$CHECK_SIG" = "true" ] ; then gpg --verify /${TIKA_JAR_NAME}-${TIKA_VE
 
 FROM dependencies as runtime
 RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-ARG TIKA_VERSION
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 ARG TIKA_JAR_NAME

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:focal as base
 RUN apt-get update
 
 FROM base as dependencies
-ARG JRE='openjdk-16-jre-headless'
+ARG JRE='openjdk-17-jre-headless'
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,3 +1,4 @@
+
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
@@ -14,7 +15,8 @@ RUN apt-get update
 
 FROM base as dependencies
 ARG JRE='openjdk-14-jre-headless'
-
+# "random" uid/gid hopefully not used anywhere else
+ARG UID_GID="35002:35002"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE
 
 FROM dependencies as fetch_tika
@@ -43,7 +45,7 @@ RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
-
+USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 

--- a/sample-configs/ner/run_tika_server.sh
+++ b/sample-configs/ner/run_tika_server.sh
@@ -57,6 +57,6 @@ echo "EMAIL=(?:[a-z0-9!#$%&'*+/=?^_\`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_\`{|}~-]+)*
 # Can be a single implementation or comma seperated list for multiple for "ner.impl.class" property
 RECOGNISERS=org.apache.tika.parser.ner.opennlp.OpenNLPNERecogniser,org.apache.tika.parser.ner.regex.RegexNERecogniser
 # Set classpath to the Tika Server JAR and the /ner folder so it has the configuration and models from above
-CLASSPATH=/ner:/tika-server-${TIKA_VERSION}.jar
+CLASSPATH=/ner:/${TIKA_JAR}-${TIKA_VERSION}.jar
 # Run the server with the custom configuration ner.impl.class property and custom /ner/tika-config.xml
-exec java -Dner.impl.class=$RECOGNISERS -cp $CLASSPATH org.apache.tika.server.TikaServerCli -h 0.0.0.0 -c /ner/tika-config.xml
+exec java -Dner.impl.class=$RECOGNISERS -cp $CLASSPATH ${TIKA_SERVER_CLASS} -h 0.0.0.0 -c /ner/tika-config.xml

--- a/sample-configs/ner/run_tika_server.sh
+++ b/sample-configs/ner/run_tika_server.sh
@@ -57,6 +57,6 @@ echo "EMAIL=(?:[a-z0-9!#$%&'*+/=?^_\`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_\`{|}~-]+)*
 # Can be a single implementation or comma seperated list for multiple for "ner.impl.class" property
 RECOGNISERS=org.apache.tika.parser.ner.opennlp.OpenNLPNERecogniser,org.apache.tika.parser.ner.regex.RegexNERecogniser
 # Set classpath to the Tika Server JAR and the /ner folder so it has the configuration and models from above
-CLASSPATH=/ner:/tika-server-${TAG}.jar
+CLASSPATH=/ner:/tika-server-${TIKA_VERSION}.jar
 # Run the server with the custom configuration ner.impl.class property and custom /ner/tika-config.xml
 exec java -Dner.impl.class=$RECOGNISERS -cp $CLASSPATH org.apache.tika.server.TikaServerCli -h 0.0.0.0 -c /ner/tika-config.xml


### PR DESCRIPTION
…esn't run as root. The following tests still pass after this change.

```
$ ./docker-tool.sh build 1.26
$ ./docker-tool.sh test 1.26
2be3cb0532d10f4a4efa163d856dd72738d8acd2e625a4668c270e350d7d5135
Image: apache/tika:1.26 - Passed
1.26
1.26
60411633a11e85fcfce0e1f61c34f40f0ff89dc01faae69310a2b1ca2c3ece38
Image: apache/tika:1.26-full - Passed
1.26-full
1.26-full
```